### PR TITLE
Expose Job jid

### DIFF
--- a/src/proto/single/mod.rs
+++ b/src/proto/single/mod.rs
@@ -126,6 +126,11 @@ impl Job {
         }
     }
 
+    /// This job's id.
+    pub fn jid(&self) -> &str {
+        &self.jid
+    }
+
     /// This job's type.
     pub fn kind(&self) -> &str {
         &self.kind


### PR DESCRIPTION
For tracing in my application I want to be able to return the jid of the job enqueued as the result of a request. This small change makes `jid` available on `Job`.