### PR TITLE
Rework consumer type to use function-like-object via a trait

### DIFF
--- a/tests/consumer.rs
+++ b/tests/consumer.rs
@@ -64,7 +64,7 @@ fn hello_pwd() {
 fn dequeue() {
     let mut s = mock::Stream::default();
     let mut c = ConsumerBuilder::default();
-    c.register("foobar", |job| -> io::Result<()> {
+    c.register("foobar", |job: Job| -> io::Result<()> {
         assert_eq!(job.args(), &["z"]);
         Ok(())
     });
@@ -103,7 +103,7 @@ fn dequeue() {
 fn dequeue_first_empty() {
     let mut s = mock::Stream::default();
     let mut c = ConsumerBuilder::default();
-    c.register("foobar", |job| -> io::Result<()> {
+    c.register("foobar", |job: Job| -> io::Result<()> {
         assert_eq!(job.args(), &["z"]);
         Ok(())
     });


### PR DESCRIPTION
…instead of closures.

It seems to actually work quite smoothly, and you can still pass closures into it to create job runners.  So, this is strictly more powerful, I think.

One potential inconvenience is the trait takes `&self` instead of `&mut self`; changing that would require making callbacks an `Arc<FnvHashmap<..., Mutex<JobRunner>>>` instead of just `Arc<FnvHashmap<...>>`.  I dunno which way is the best.  You can work around it when you implement `JobRunner` just by making all its fields that need to mutate interior-mutable with `Mutex` or such, so it's not a killer.  Might even be nicer this way so you don't *have* to lock stuff when you don't need to.

I sorta feel like having a thread pool internal to the `Consumer` is a bit wonky, and it should be possible to have a `Consumer` that defines operations and a `ConsumerRunner` that may have different strategies for running it; that way we could maybe loosen some `Send` and `Sync` constraints on `JobRunner`'s.  I'm trying to use this where each job needs to use tokio to do some async communication watsit, so each `JobRunner` type includes a thread pool anyway, and it feels a bit redundant.  This isn't a design issue I know how to fix yet though.