### PR TITLE
perform_in and perform_at

### DIFF
--- a/src/producer/mod.rs
+++ b/src/producer/mod.rs
@@ -120,7 +120,6 @@ impl<S: Read + Write> Producer<S> {
         self.enqueue(job)
     }
 
-
     /// Enqueue the given job on the Faktory server to be performed at a certain time
     ///
     /// Returns `Ok` if the job was successfully queued by the Faktory server.
@@ -155,8 +154,6 @@ impl<S: Read + Write> Producer<S> {
     pub fn enqueue_at(&mut self, job: Job, at: DateTime<Utc>) -> Result<(), Error> {
         self.perform_at(job, at)
     }
-
-    
 
     /// Retrieve information about the running server.
     ///

--- a/tests/producer.rs
+++ b/tests/producer.rs
@@ -6,7 +6,7 @@ extern crate url;
 
 mod mock;
 
-use chrono::{Duration, Utc, DateTime};
+use chrono::{DateTime, Duration, Utc};
 use faktory::*;
 
 #[test]
@@ -138,7 +138,8 @@ fn perform_at() {
     // p.perform_at(Job::new("foobar", vec!["z"])).unwrap();
 
     let now = Utc::now();
-    p.perform_at(Job::new("foobar", vec!["z"]), now + Duration::seconds(15)).unwrap();
+    p.perform_at(Job::new("foobar", vec!["z"]), now + Duration::seconds(15))
+        .unwrap();
 
     let written = s.pop_bytes_written(0);
     assert!(written.starts_with(b"PUSH {"));


### PR DESCRIPTION
Added functionality for scheduled jobs (via the `at` field in `Job`), which to the best of what I can tell, was not currently implemented.

I named these methods based on the Ruby/sidekiq client. `perform_in` and `perform_at` take a duration for how long in the future should be scheduled for and a specific time to schedule a job to be enqueued, respectively.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jonhoo/faktory-rs/24)
<!-- Reviewable:end -->
