### PR TITLE
Transition to `std::error::Error`; minor cleanup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,9 +35,9 @@ chrono = { version = "0.4", features = ["serde"] }
 url = "2"
 atomic-option = "0.1"
 fnv = "1.0.3"
-failure = "0.1"
 native-tls = { version = "0.2", optional = true }
 clap = { version = "2.27.1", optional = true }
+thiserror = "1.0.30"
 
 [dev-dependencies]
 mockstream = "0.0.3"

--- a/src/bin/loadtest.rs
+++ b/src/bin/loadtest.rs
@@ -1,6 +1,5 @@
 #[macro_use]
 extern crate clap;
-extern crate failure;
 extern crate faktory;
 extern crate rand;
 extern crate serde_json;
@@ -54,7 +53,7 @@ fn main() {
     let popped = sync::Arc::new(atomic::AtomicUsize::new(0));
 
     let start = time::Instant::now();
-    let threads: Vec<thread::JoinHandle<Result<_, failure::Error>>> = (0..threads)
+    let threads: Vec<thread::JoinHandle<Result<_, Error>>> = (0..threads)
         .map(|_| {
             let pushed = sync::Arc::clone(&pushed);
             let popped = sync::Arc::clone(&popped);

--- a/src/consumer/mod.rs
+++ b/src/consumer/mod.rs
@@ -397,7 +397,7 @@ where
                     // the resulting OK that failed. in that case, we would get an error response
                     // when re-sending the job response. this should not count as critical. other
                     // errors, however, should!
-                    if let Error::GenericIO(_) = e {
+                    if let Error::IO(_) = e {
                         last_job_result.swap(res, atomic::Ordering::SeqCst);
                         return Err(e);
                     }

--- a/src/consumer/mod.rs
+++ b/src/consumer/mod.rs
@@ -251,8 +251,7 @@ impl<E, S: Read + Write> Consumer<S, E> {
 
 impl<E, S: Read + Write + Reconnect> Consumer<S, E> {
     fn reconnect(&mut self) -> Result<(), Error> {
-        self.c.reconnect()?;
-        Ok(())
+        self.c.reconnect()
     }
 }
 

--- a/src/consumer/mod.rs
+++ b/src/consumer/mod.rs
@@ -1,6 +1,6 @@
+use crate::error::Error;
 use crate::proto::{self, Client, ClientOptions, HeartbeatStatus, Reconnect};
 use atomic_option::AtomicOption;
-use failure::Error;
 use fnv::FnvHashMap;
 use std::error::Error as StdError;
 use std::io::prelude::*;
@@ -251,7 +251,8 @@ impl<E, S: Read + Write> Consumer<S, E> {
 
 impl<E, S: Read + Write + Reconnect> Consumer<S, E> {
     fn reconnect(&mut self) -> Result<(), Error> {
-        self.c.reconnect()
+        self.c.reconnect()?;
+        Ok(())
     }
 }
 
@@ -397,7 +398,7 @@ where
                     // the resulting OK that failed. in that case, we would get an error response
                     // when re-sending the job response. this should not count as critical. other
                     // errors, however, should!
-                    if e.downcast_ref::<::std::io::Error>().is_some() {
+                    if let Error::GenericIO(_) = e {
                         last_job_result.swap(res, atomic::Ordering::SeqCst);
                         return Err(e);
                     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -45,7 +45,7 @@ pub enum Error {
     /// Indicates an error in the underlying TLS stream.
     #[cfg(feature = "tls")]
     #[error("underlying tls stream")]
-    TlsStream(#[from] native_tls::Error),
+    TlsStream(#[source] native_tls::Error),
 }
 
 /// Errors specific to connection logic.

--- a/src/error.rs
+++ b/src/error.rs
@@ -50,6 +50,7 @@ pub enum Error {
 
 /// Errors specific to connection logic.
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum Connect {
     /// The scheme portion of the connection address provided is invalid.
     #[error("unknown scheme: {scheme}")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -37,10 +37,10 @@ pub enum Error {
 
     /// Faktory payloads are JSON encoded.
     ///
-    /// This error is one that was encountered when attempting to deserialize a response from the server.
+    /// This error is one that was encountered when attempting to serialize or deserialize communication with the server.
     /// These generally indicate a mismatch between what the client expects and what the server provided.
-    #[error("deserialize payload")]
-    DeserializePayload(#[source] serde_json::Error),
+    #[error("serialization")]
+    Serialization(#[source] serde_json::Error),
 
     /// Indicates an error in the underlying TLS stream.
     #[cfg(feature = "tls")]
@@ -150,5 +150,5 @@ impl Protocol {
 }
 
 pub(crate) fn wrap_serde_io(err: std::io::Error) -> Error {
-    Error::DeserializePayload(serde_json::Error::io(err))
+    Error::Serialization(serde_json::Error::io(err))
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,16 +1,16 @@
 //! Enumerates all errors that this crate may return.
 //!
-//! [Error] is the top level error enum.
+//! [`Error`] is the top level error enum.
 //! Most consumers should only need to interact with this type.
 //! This is also where more generic errors such as IO errors are placed,
-//! whereas the more specific errors ([Connection] and [Protocol]) are
+//! whereas the more specific errors ([`Connection`] and [`Protocol`]) are
 //! related to logic.
 //!
-//! [Connect] describes errors specific to the connection logic, for example
+//! [`Connect`] describes errors specific to the connection logic, for example
 //! version mismatches or an invalid URL.
 //!
-//! [Protocol] describes lower-level errors relating to communication
-//! with the faktory server. Typically, [Protocol] errors are the result
+//! [`Protocol`] describes lower-level errors relating to communication
+//! with the faktory server. Typically, [`Protocol`] errors are the result
 //! of the server sending a response this client did not expect.
 
 use thiserror::Error;

--- a/src/error.rs
+++ b/src/error.rs
@@ -40,7 +40,7 @@ pub enum Error {
     /// This error is one that was encountered when attempting to deserialize a response from the server.
     /// These generally indicate a mismatch between what the client expects and what the server provided.
     #[error("deserialize payload")]
-    DeserializePayload(#[from] serde_json::Error),
+    DeserializePayload(#[source] serde_json::Error),
 
     /// Indicates an error in the underlying TLS stream.
     #[cfg(feature = "tls")]
@@ -147,4 +147,8 @@ impl Protocol {
             },
         }
     }
+}
+
+pub(crate) fn wrap_serde_io(err: std::io::Error) -> Error {
+    Error::DeserializePayload(serde_json::Error::io(err))
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,26 +1,52 @@
-/// The set of observable application-level errors when interacting with a Faktory server.
-#[derive(Debug, Fail)]
+use thiserror::Error;
+
+use crate::proto::ConnectError;
+
+/// The set of observable errors when interacting with a Faktory server.
+#[derive(Debug, Error)]
 #[allow(clippy::manual_non_exhaustive)]
-pub enum FaktoryError {
+pub enum Error {
+    /// The connection to the server, or one of its prerequisites, failed.
+    #[error("connection error: {0}")]
+    Connect(#[from] ConnectError),
+
+    /// Underlying io layer errors.
+    /// These are overwhelmingly network communication errors on the socket connection to the server.
+    #[error("underlying i/o: {0}")]
+    GenericIO(#[from] std::io::Error),
+
+    /// Application-level errors.
+    /// These generally indicate a mismatch between what the client expects and what the server expects.
+    #[error("protocol: {0}")]
+    Protocol(#[from] Protocol),
+
+    /// Faktory payloads are JSON encoded.
+    /// This error is one that was encountered when attempting to deserialize a response from the server.
+    /// These generally indicate a mismatch between what the client expects and what the server provided.
+    #[error("deserialize payload: {0}")]
+    DeserializePayload(#[from] serde_json::Error),
+}
+
+/// The set of observable application-level errors when interacting with a Faktory server.
+#[derive(Debug, Error)]
+#[allow(clippy::manual_non_exhaustive)]
+pub enum Protocol {
     /// The server reports that an issued request was malformed.
-    #[fail(display = "request was malformed: {}", desc)]
+    #[error("request was malformed: {desc}")]
     Malformed {
         /// Error reported by server
         desc: String,
     },
 
     /// The server responded with an error.
-    #[fail(display = "an internal server error occurred: {}", msg)]
+    #[error("an internal server error occurred: {msg}")]
     Internal {
         /// The error message given by the server.
         msg: String,
     },
 
     /// The server sent a response that did not match what was expected.
-    #[fail(
-        display = "expected {}, got unexpected response: {}",
-        expected, received
-    )]
+    #[error("expected {expected}, got unexpected response: {received}")]
     BadType {
         /// The expected response type.
         expected: &'static str,
@@ -30,10 +56,7 @@ pub enum FaktoryError {
     },
 
     /// The server sent a malformed response.
-    #[fail(
-        display = "server sent malformed {} response: {} in {:?}",
-        typed_as, error, bytes
-    )]
+    #[error("server sent malformed {typed_as} response: {error} in {bytes:?}")]
     BadResponse {
         /// The type of the server response.
         typed_as: &'static str,
@@ -47,30 +70,32 @@ pub enum FaktoryError {
 
     // We're going to add more error types in the future
     // https://github.com/rust-lang/rust/issues/44109
-    #[fail(display = "unreachable")]
+    //
+    // This forces users to write pattern matches with a catch-all `_` arm.
+    #[error("unreachable")]
     #[doc(hidden)]
     __Nonexhaustive,
 }
 
-impl FaktoryError {
+impl Protocol {
     pub(crate) fn new(line: String) -> Self {
         let mut parts = line.splitn(2, ' ');
         let code = parts.next();
         let error = parts.next();
         if error.is_none() {
-            return FaktoryError::Internal {
+            return Protocol::Internal {
                 msg: code.unwrap().to_string(),
             };
         }
         let error = error.unwrap().to_string();
 
         match code {
-            Some("ERR") => FaktoryError::Internal { msg: error },
-            Some("MALFORMED") => FaktoryError::Malformed { desc: error },
-            Some(c) => FaktoryError::Internal {
+            Some("ERR") => Protocol::Internal { msg: error },
+            Some("MALFORMED") => Protocol::Malformed { desc: error },
+            Some(c) => Protocol::Internal {
                 msg: format!("{} {}", c, error),
             },
-            None => FaktoryError::Internal {
+            None => Protocol::Internal {
                 msg: "empty error response".to_string(),
             },
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -30,6 +30,14 @@ pub enum Error {
     #[cfg(feature = "tls")]
     #[error("underlying tls stream: {0}")]
     TlsStream(#[from] native_tls::Error),
+
+    // We're going to add more error types in the future
+    // https://github.com/rust-lang/rust/issues/44109
+    //
+    // This forces users to write pattern matches with a catch-all `_` arm.
+    #[error("unreachable")]
+    #[doc(hidden)]
+    __Nonexhaustive,
 }
 
 /// The set of observable application-level errors when interacting with a Faktory server.

--- a/src/error.rs
+++ b/src/error.rs
@@ -23,10 +23,10 @@ pub enum Error {
     #[error("connection")]
     Connect(#[from] Connect),
 
-    /// Underlying IO layer errors.
+    /// Underlying I/O layer errors.
     ///
     /// These are overwhelmingly network communication errors on the socket connection to the server.
-    #[error("underlying IO")]
+    #[error("underlying I/O")]
     IO(#[from] std::io::Error),
 
     /// Application-level errors.

--- a/src/error.rs
+++ b/src/error.rs
@@ -148,7 +148,3 @@ impl Protocol {
         }
     }
 }
-
-pub(crate) fn wrap_serde_io(err: std::io::Error) -> Error {
-    Error::Serialization(serde_json::Error::io(err))
-}

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,7 +2,7 @@
 //!
 //! [`Error`] is the top level error enum.
 //! Most consumers should only need to interact with this type.
-//! This is also where more generic errors such as IO errors are placed,
+//! This is also where more generic errors such as I/O errors are placed,
 //! whereas the more specific errors ([`Connection`] and [`Protocol`]) are
 //! related to logic.
 //!

--- a/src/error.rs
+++ b/src/error.rs
@@ -25,6 +25,11 @@ pub enum Error {
     /// These generally indicate a mismatch between what the client expects and what the server provided.
     #[error("deserialize payload: {0}")]
     DeserializePayload(#[from] serde_json::Error),
+
+    /// Indicates an error in the underlying TLS stream.
+    #[cfg(feature = "tls")]
+    #[error("underlying tls stream: {0}")]
+    TlsStream(#[from] native_tls::Error),
 }
 
 /// The set of observable application-level errors when interacting with a Faktory server.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,7 +71,7 @@ mod tls;
 pub use tls::TlsStream;
 
 pub use crate::consumer::{Consumer, ConsumerBuilder};
-pub use crate::error::{Error, Protocol};
+pub use crate::error::{Error, ProtocolError};
 pub use crate::producer::Producer;
 pub use crate::proto::Job;
 pub use crate::proto::Reconnect;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,8 +58,6 @@
 #![warn(rust_2018_idioms)]
 
 #[macro_use]
-extern crate failure;
-#[macro_use]
 extern crate serde_derive;
 
 mod consumer;
@@ -73,7 +71,7 @@ mod tls;
 pub use tls::TlsStream;
 
 pub use crate::consumer::{Consumer, ConsumerBuilder};
-pub use crate::error::FaktoryError;
+pub use crate::error::{Error, Protocol};
 pub use crate::producer::Producer;
 pub use crate::proto::Job;
 pub use crate::proto::Reconnect;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,7 @@
 extern crate serde_derive;
 
 mod consumer;
-mod error;
+pub mod error;
 mod producer;
 mod proto;
 
@@ -71,7 +71,7 @@ mod tls;
 pub use tls::TlsStream;
 
 pub use crate::consumer::{Consumer, ConsumerBuilder};
-pub use crate::error::{Error, ProtocolError};
+pub use crate::error::Error;
 pub use crate::producer::Producer;
 pub use crate::proto::Job;
 pub use crate::proto::Reconnect;

--- a/src/producer/mod.rs
+++ b/src/producer/mod.rs
@@ -105,36 +105,31 @@ impl<S: Read + Write> Producer<S> {
     ///
     /// Returns `Ok` if the job was successfully queued by the Faktory server.
     pub fn enqueue(&mut self, job: Job) -> Result<()> {
-        self.c.issue(&Push::from(job))?.await_ok()?;
-        Ok(())
+        self.c.issue(&Push::from(job))?.await_ok()
     }
 
     /// Retrieve information about the running server.
     ///
     /// The returned value is the result of running the `INFO` command on the server.
     pub fn info(&mut self) -> Result<serde_json::Value> {
-        let v = self
-            .c
+        self.c
             .issue(&Info)?
             .read_json()
-            .map(|v| v.expect("info command cannot give empty response"))?;
-        Ok(v)
+            .map(|v| v.expect("info command cannot give empty response"))
     }
 
     /// Pause the given queues.
     pub fn queue_pause<T: AsRef<str>>(&mut self, queues: &[T]) -> Result<()> {
         self.c
             .issue(&QueueControl::new(QueueAction::Pause, queues))?
-            .await_ok()?;
-        Ok(())
+            .await_ok()
     }
 
     /// Resume the given queues.
     pub fn queue_resume<T: AsRef<str>>(&mut self, queues: &[T]) -> Result<()> {
         self.c
             .issue(&QueueControl::new(QueueAction::Resume, queues))?
-            .await_ok()?;
-        Ok(())
+            .await_ok()
     }
 }
 

--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -203,8 +203,7 @@ impl<S: Read + Write> Client<S> {
             }
         }
 
-        single::write_command_and_await_ok(&mut self.stream, &hello)?;
-        Ok(())
+        single::write_command_and_await_ok(&mut self.stream, &hello)
     }
 }
 

--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -1,11 +1,9 @@
-use crate::error::Error;
-use crate::ProtocolError;
+use crate::error::{Connect, Error, Protocol};
 use bufstream::BufStream;
 use libc::getpid;
 use std::io;
 use std::io::prelude::*;
 use std::net::TcpStream;
-use thiserror::Error;
 use url::Url;
 
 pub(crate) const EXPECTED_PROTOCOL_VERSION: usize = 2;
@@ -18,23 +16,6 @@ pub use self::single::{Ack, Fail, Heartbeat, Info, Job, Push, QueueAction, Queue
 // responses that users can see
 pub use self::single::Hi;
 
-#[derive(Debug, Error)]
-pub enum ConnectError {
-    #[error("unknown scheme: {scheme}")]
-    BadScheme { scheme: String },
-    #[error("no hostname given")]
-    MissingHostname,
-    #[error("server requires authentication")]
-    AuthenticationNeeded,
-    #[error("server version mismatch (theirs: {theirs}, ours: {ours})")]
-    VersionMismatch { ours: usize, theirs: usize },
-    #[error("parse URL: {0}")]
-    ParseUrl(#[source] url::ParseError),
-}
-
-/// Default Error type, aliased in module for convenience.
-type Result<T> = std::result::Result<T, Error>;
-
 pub(crate) fn get_env_url() -> String {
     use std::env;
     let var = env::var("FAKTORY_PROVIDER").unwrap_or_else(|_| "FAKTORY_URL".to_string());
@@ -45,17 +26,17 @@ pub(crate) fn host_from_url(url: &Url) -> String {
     format!("{}:{}", url.host_str().unwrap(), url.port().unwrap_or(7419))
 }
 
-pub(crate) fn url_parse(url: &str) -> Result<Url> {
-    let url = Url::parse(url).map_err(ConnectError::ParseUrl)?;
+pub(crate) fn url_parse(url: &str) -> Result<Url, Error> {
+    let url = Url::parse(url).map_err(Connect::ParseUrl)?;
     if url.scheme() != "tcp" {
-        return Err(ConnectError::BadScheme {
+        return Err(Connect::BadScheme {
             scheme: url.scheme().to_string(),
         }
         .into());
     }
 
     if url.host_str().is_none() || url.host_str().unwrap().is_empty() {
-        return Err(ConnectError::MissingHostname.into());
+        return Err(Connect::MissingHostname.into());
     }
 
     Ok(url)
@@ -120,12 +101,12 @@ impl<S> Client<S>
 where
     S: Read + Write + Reconnect,
 {
-    pub(crate) fn connect_again(&self) -> Result<Self> {
+    pub(crate) fn connect_again(&self) -> Result<Self, Error> {
         let s = self.stream.get_ref().reconnect()?;
         Client::new(s, self.opts.clone())
     }
 
-    pub fn reconnect(&mut self) -> Result<()> {
+    pub fn reconnect(&mut self) -> Result<(), Error> {
         let s = self.stream.get_ref().reconnect()?;
         self.stream = BufStream::new(s);
         self.init()
@@ -133,7 +114,7 @@ where
 }
 
 impl<S: Read + Write> Client<S> {
-    pub(crate) fn new(stream: S, opts: ClientOptions) -> Result<Client<S>> {
+    pub(crate) fn new(stream: S, opts: ClientOptions) -> Result<Client<S>, Error> {
         let mut c = Client {
             stream: BufStream::new(stream),
             opts,
@@ -142,7 +123,7 @@ impl<S: Read + Write> Client<S> {
         Ok(c)
     }
 
-    pub(crate) fn new_producer(stream: S, pwd: Option<String>) -> Result<Client<S>> {
+    pub(crate) fn new_producer(stream: S, pwd: Option<String>) -> Result<Client<S>, Error> {
         let opts = ClientOptions {
             password: pwd,
             is_producer: true,
@@ -153,11 +134,11 @@ impl<S: Read + Write> Client<S> {
 }
 
 impl<S: Read + Write> Client<S> {
-    fn init(&mut self) -> Result<()> {
+    fn init(&mut self) -> Result<(), Error> {
         let hi = single::read_hi(&mut self.stream)?;
 
         if hi.version != EXPECTED_PROTOCOL_VERSION {
-            return Err(ConnectError::VersionMismatch {
+            return Err(Connect::VersionMismatch {
                 ours: EXPECTED_PROTOCOL_VERSION,
                 theirs: hi.version,
             }
@@ -199,7 +180,7 @@ impl<S: Read + Write> Client<S> {
             if let Some(ref pwd) = self.opts.password {
                 hello.set_password(&hi, pwd);
             } else {
-                return Err(ConnectError::AuthenticationNeeded.into());
+                return Err(Connect::AuthenticationNeeded.into());
             }
         }
 
@@ -225,12 +206,12 @@ impl<S: Read + Write> Client<S> {
     pub(crate) fn issue<FC: self::single::FaktoryCommand>(
         &mut self,
         c: &FC,
-    ) -> Result<ReadToken<'_, S>> {
+    ) -> Result<ReadToken<'_, S>, Error> {
         single::write_command(&mut self.stream, c)?;
         Ok(ReadToken(self))
     }
 
-    pub(crate) fn heartbeat(&mut self) -> Result<HeartbeatStatus> {
+    pub(crate) fn heartbeat(&mut self) -> Result<HeartbeatStatus, Error> {
         single::write_command(
             &mut self.stream,
             &Heartbeat::new(&**self.opts.wid.as_ref().unwrap()),
@@ -245,7 +226,7 @@ impl<S: Read + Write> Client<S> {
             {
                 Some("terminate") => Ok(HeartbeatStatus::Terminate),
                 Some("quiet") => Ok(HeartbeatStatus::Quiet),
-                _ => Err(ProtocolError::BadType {
+                _ => Err(Protocol::BadType {
                     expected: "heartbeat response",
                     received: format!("{}", s),
                 }
@@ -254,7 +235,7 @@ impl<S: Read + Write> Client<S> {
         }
     }
 
-    pub(crate) fn fetch<Q>(&mut self, queues: &[Q]) -> Result<Option<Job>>
+    pub(crate) fn fetch<Q>(&mut self, queues: &[Q]) -> Result<Option<Job>, Error>
     where
         Q: AsRef<str>,
     {
@@ -263,11 +244,11 @@ impl<S: Read + Write> Client<S> {
 }
 
 impl<'a, S: Read + Write> ReadToken<'a, S> {
-    pub(crate) fn await_ok(self) -> Result<()> {
+    pub(crate) fn await_ok(self) -> Result<(), Error> {
         single::read_ok(&mut self.0.stream)
     }
 
-    pub(crate) fn read_json<T>(self) -> Result<Option<T>>
+    pub(crate) fn read_json<T>(self) -> Result<Option<T>, Error>
     where
         T: serde::de::DeserializeOwned,
     {

--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -1,5 +1,5 @@
 use crate::error::Error;
-use crate::Protocol;
+use crate::ProtocolError;
 use bufstream::BufStream;
 use libc::getpid;
 use std::io;
@@ -245,7 +245,7 @@ impl<S: Read + Write> Client<S> {
             {
                 Some("terminate") => Ok(HeartbeatStatus::Terminate),
                 Some("quiet") => Ok(HeartbeatStatus::Quiet),
-                _ => Err(Protocol::BadType {
+                _ => Err(ProtocolError::BadType {
                     expected: "heartbeat response",
                     received: format!("{}", s),
                 }

--- a/src/proto/single/cmd.rs
+++ b/src/proto/single/cmd.rs
@@ -44,7 +44,7 @@ pub struct Ack {
 impl FaktoryCommand for Ack {
     fn issue<W: Write>(&self, w: &mut dyn Write) -> Result<(), Error> {
         w.write_all(b"ACK ").map_err(error::wrap_serde_io)?;
-        serde_json::to_writer(&mut *w, self).map_err(Error::DeserializePayload)?;
+        serde_json::to_writer(&mut *w, self).map_err(Error::Serialization)?;
         w.write_all(b"\r\n").map_err(error::wrap_serde_io)
     }
 }
@@ -67,7 +67,7 @@ pub struct Heartbeat {
 impl FaktoryCommand for Heartbeat {
     fn issue<W: Write>(&self, w: &mut dyn Write) -> Result<(), Error> {
         w.write_all(b"BEAT ").map_err(error::wrap_serde_io)?;
-        serde_json::to_writer(&mut *w, self).map_err(Error::DeserializePayload)?;
+        serde_json::to_writer(&mut *w, self).map_err(Error::Serialization)?;
         w.write_all(b"\r\n").map_err(error::wrap_serde_io)
     }
 }
@@ -94,7 +94,7 @@ pub struct Fail {
 impl FaktoryCommand for Fail {
     fn issue<W: Write>(&self, w: &mut dyn Write) -> Result<(), Error> {
         w.write_all(b"FAIL ").map_err(error::wrap_serde_io)?;
-        serde_json::to_writer(&mut *w, self).map_err(Error::DeserializePayload)?;
+        serde_json::to_writer(&mut *w, self).map_err(Error::Serialization)?;
         w.write_all(b"\r\n").map_err(error::wrap_serde_io)
     }
 }
@@ -146,7 +146,7 @@ where
             w.write_all(b"FETCH\r\n").map_err(error::wrap_serde_io)?;
         } else {
             w.write_all(b"FETCH").map_err(error::wrap_serde_io)?;
-            write_queues::<W, _>(w, self.queues).map_err(Error::DeserializePayload)?;
+            write_queues::<W, _>(w, self.queues).map_err(Error::Serialization)?;
             w.write_all(b"\r\n").map_err(error::wrap_serde_io)?;
         }
         Ok(())
@@ -214,7 +214,7 @@ impl Hello {
 impl FaktoryCommand for Hello {
     fn issue<W: Write>(&self, w: &mut dyn Write) -> Result<(), Error> {
         w.write_all(b"HELLO ").map_err(error::wrap_serde_io)?;
-        serde_json::to_writer(&mut *w, self).map_err(Error::DeserializePayload)?;
+        serde_json::to_writer(&mut *w, self).map_err(Error::Serialization)?;
         w.write_all(b"\r\n").map_err(error::wrap_serde_io)
     }
 }
@@ -240,7 +240,7 @@ impl From<Job> for Push {
 impl FaktoryCommand for Push {
     fn issue<W: Write>(&self, w: &mut dyn Write) -> Result<(), Error> {
         w.write_all(b"PUSH ").map_err(error::wrap_serde_io)?;
-        serde_json::to_writer(&mut *w, &**self).map_err(Error::DeserializePayload)?;
+        serde_json::to_writer(&mut *w, &**self).map_err(Error::Serialization)?;
         w.write_all(b"\r\n").map_err(error::wrap_serde_io)
     }
 }
@@ -268,7 +268,7 @@ impl<S: AsRef<str>> FaktoryCommand for QueueControl<'_, S> {
         };
 
         w.write_all(command).map_err(error::wrap_serde_io)?;
-        write_queues::<W, _>(w, self.queues).map_err(Error::DeserializePayload)?;
+        write_queues::<W, _>(w, self.queues).map_err(Error::Serialization)?;
         w.write_all(b"\r\n").map_err(error::wrap_serde_io)
     }
 }

--- a/src/proto/single/cmd.rs
+++ b/src/proto/single/cmd.rs
@@ -1,6 +1,8 @@
-use crate::error;
+use crate::{
+    error::{self, Error},
+    Job,
+};
 
-use super::{Error, Job};
 use std::io::prelude::*;
 
 pub trait FaktoryCommand {

--- a/src/proto/single/cmd.rs
+++ b/src/proto/single/cmd.rs
@@ -1,16 +1,13 @@
 use super::{Error, Job};
 use std::io::prelude::*;
 
-/// Default Error type, aliased in module for convenience.
-type Result<T> = std::result::Result<T, Error>;
-
 pub trait FaktoryCommand {
-    fn issue<W: Write>(&self, w: &mut dyn Write) -> Result<()>;
+    fn issue<W: Write>(&self, w: &mut dyn Write) -> Result<(), Error>;
 }
 
 /// Write queues as part of a command. They are written with a leading space
 /// followed by space separated queue names.
-fn write_queues<W, S>(w: &mut dyn Write, queues: &[S]) -> std::result::Result<(), serde_json::Error>
+fn write_queues<W, S>(w: &mut dyn Write, queues: &[S]) -> Result<(), serde_json::Error>
 where
     W: Write,
     S: AsRef<str>,
@@ -29,7 +26,7 @@ where
 pub struct Info;
 
 impl FaktoryCommand for Info {
-    fn issue<W: Write>(&self, w: &mut dyn Write) -> Result<()> {
+    fn issue<W: Write>(&self, w: &mut dyn Write) -> Result<(), Error> {
         Ok(w.write_all(b"INFO\r\n").map_err(serde_json::Error::io)?)
     }
 }
@@ -43,7 +40,7 @@ pub struct Ack {
 }
 
 impl FaktoryCommand for Ack {
-    fn issue<W: Write>(&self, w: &mut dyn Write) -> Result<()> {
+    fn issue<W: Write>(&self, w: &mut dyn Write) -> Result<(), Error> {
         w.write_all(b"ACK ").map_err(serde_json::Error::io)?;
         serde_json::to_writer(&mut *w, self)?;
         Ok(w.write_all(b"\r\n").map_err(serde_json::Error::io)?)
@@ -66,7 +63,7 @@ pub struct Heartbeat {
 }
 
 impl FaktoryCommand for Heartbeat {
-    fn issue<W: Write>(&self, w: &mut dyn Write) -> Result<()> {
+    fn issue<W: Write>(&self, w: &mut dyn Write) -> Result<(), Error> {
         w.write_all(b"BEAT ").map_err(serde_json::Error::io)?;
         serde_json::to_writer(&mut *w, self)?;
         Ok(w.write_all(b"\r\n").map_err(serde_json::Error::io)?)
@@ -93,7 +90,7 @@ pub struct Fail {
 }
 
 impl FaktoryCommand for Fail {
-    fn issue<W: Write>(&self, w: &mut dyn Write) -> Result<()> {
+    fn issue<W: Write>(&self, w: &mut dyn Write) -> Result<(), Error> {
         w.write_all(b"FAIL ").map_err(serde_json::Error::io)?;
         serde_json::to_writer(&mut *w, self)?;
         Ok(w.write_all(b"\r\n").map_err(serde_json::Error::io)?)
@@ -124,7 +121,7 @@ impl Fail {
 pub struct End;
 
 impl FaktoryCommand for End {
-    fn issue<W: Write>(&self, w: &mut dyn Write) -> Result<()> {
+    fn issue<W: Write>(&self, w: &mut dyn Write) -> Result<(), Error> {
         Ok(w.write_all(b"END\r\n").map_err(serde_json::Error::io)?)
     }
 }
@@ -142,7 +139,7 @@ impl<'a, S> FaktoryCommand for Fetch<'a, S>
 where
     S: AsRef<str>,
 {
-    fn issue<W: Write>(&self, w: &mut dyn Write) -> Result<()> {
+    fn issue<W: Write>(&self, w: &mut dyn Write) -> Result<(), Error> {
         if self.queues.is_empty() {
             w.write_all(b"FETCH\r\n").map_err(serde_json::Error::io)?;
         } else {
@@ -213,7 +210,7 @@ impl Hello {
 }
 
 impl FaktoryCommand for Hello {
-    fn issue<W: Write>(&self, w: &mut dyn Write) -> Result<()> {
+    fn issue<W: Write>(&self, w: &mut dyn Write) -> Result<(), Error> {
         w.write_all(b"HELLO ").map_err(serde_json::Error::io)?;
         serde_json::to_writer(&mut *w, self)?;
         Ok(w.write_all(b"\r\n").map_err(serde_json::Error::io)?)
@@ -239,7 +236,7 @@ impl From<Job> for Push {
 }
 
 impl FaktoryCommand for Push {
-    fn issue<W: Write>(&self, w: &mut dyn Write) -> Result<()> {
+    fn issue<W: Write>(&self, w: &mut dyn Write) -> Result<(), Error> {
         w.write_all(b"PUSH ").map_err(serde_json::Error::io)?;
         serde_json::to_writer(&mut *w, &**self)?;
         Ok(w.write_all(b"\r\n").map_err(serde_json::Error::io)?)
@@ -262,7 +259,7 @@ where
 }
 
 impl<S: AsRef<str>> FaktoryCommand for QueueControl<'_, S> {
-    fn issue<W: Write>(&self, w: &mut dyn Write) -> Result<()> {
+    fn issue<W: Write>(&self, w: &mut dyn Write) -> Result<(), Error> {
         let command = match self.action {
             QueueAction::Pause => b"QUEUE PAUSE".as_ref(),
             QueueAction::Resume => b"QUEUE RESUME".as_ref(),

--- a/src/proto/single/mod.rs
+++ b/src/proto/single/mod.rs
@@ -72,7 +72,7 @@ pub struct Job {
     ///
     /// This field is read-only.
     #[serde(skip_serializing)]
-    pub failure: Option<Failure>,
+    failure: Option<Failure>,
 
     /// Extra context to include with the job.
     ///

--- a/src/proto/single/mod.rs
+++ b/src/proto/single/mod.rs
@@ -72,7 +72,7 @@ pub struct Job {
     ///
     /// This field is read-only.
     #[serde(skip_serializing)]
-    pub(crate) failure: Option<Failure>,
+    failure: Option<Failure>,
 
     /// Extra context to include with the job.
     ///
@@ -155,6 +155,11 @@ impl Job {
     /// The arguments provided for this job.
     pub fn args(&self) -> &[serde_json::Value] {
         &self.args
+    }
+
+    /// Data about this job's most recent failure.
+    pub fn failure(&self) -> &Option<Failure> {
+        &self.failure
     }
 }
 

--- a/src/proto/single/mod.rs
+++ b/src/proto/single/mod.rs
@@ -72,7 +72,7 @@ pub struct Job {
     ///
     /// This field is read-only.
     #[serde(skip_serializing)]
-    failure: Option<Failure>,
+    pub(crate) failure: Option<Failure>,
 
     /// Extra context to include with the job.
     ///

--- a/src/proto/single/mod.rs
+++ b/src/proto/single/mod.rs
@@ -1,10 +1,11 @@
 use chrono::{DateTime, Utc};
-use failure::Error;
 use std::collections::HashMap;
 use std::io::prelude::*;
 
 mod cmd;
 mod resp;
+
+use crate::error::Error;
 
 pub use self::cmd::*;
 pub use self::resp::*;
@@ -71,7 +72,7 @@ pub struct Job {
     ///
     /// This field is read-only.
     #[serde(skip_serializing)]
-    pub(crate) failure: Option<Failure>,
+    pub failure: Option<Failure>,
 
     /// Extra context to include with the job.
     ///

--- a/src/proto/single/resp.rs
+++ b/src/proto/single/resp.rs
@@ -1,9 +1,8 @@
-use crate::ProtocolError;
+use super::Error;
+use crate::error::Protocol;
 use std::io::prelude::*;
 
-use super::Error;
-
-fn bad(expected: &'static str, got: &RawResponse) -> ProtocolError {
+fn bad(expected: &'static str, got: &RawResponse) -> Protocol {
     let stringy = match *got {
         RawResponse::String(ref s) => Some(&**s),
         RawResponse::Blob(ref b) => {
@@ -17,11 +16,11 @@ fn bad(expected: &'static str, got: &RawResponse) -> ProtocolError {
     };
 
     match stringy {
-        Some(s) => ProtocolError::BadType {
+        Some(s) => Protocol::BadType {
             expected,
             received: s.to_string(),
         },
-        None => ProtocolError::BadType {
+        None => Protocol::BadType {
             expected,
             received: format!("{:?}", got),
         },
@@ -131,7 +130,7 @@ fn read<R: BufRead>(mut r: R) -> Result<RawResponse, Error> {
             let l = s.len() - 2;
             s.truncate(l);
 
-            Err(ProtocolError::new(s).into())
+            Err(Protocol::new(s).into())
         }
         b':' => {
             // Integer
@@ -145,7 +144,7 @@ fn read<R: BufRead>(mut r: R) -> Result<RawResponse, Error> {
 
             match (&*s).parse::<isize>() {
                 Ok(i) => Ok(RawResponse::Number(i)),
-                Err(_) => Err(ProtocolError::BadResponse {
+                Err(_) => Err(Protocol::BadResponse {
                     typed_as: "integer",
                     error: "invalid integer value",
                     bytes: s.into_bytes(),
@@ -159,14 +158,14 @@ fn read<R: BufRead>(mut r: R) -> Result<RawResponse, Error> {
             let mut bytes = Vec::with_capacity(32);
             r.read_until(b'\n', &mut bytes)?;
             let s = std::str::from_utf8(&bytes[0..bytes.len() - 2]).map_err(|_| {
-                ProtocolError::BadResponse {
+                Protocol::BadResponse {
                     typed_as: "bulk string",
                     error: "server bulk response contains non-utf8 size prefix",
                     bytes: bytes[0..bytes.len() - 2].to_vec(),
                 }
             })?;
 
-            let size = s.parse::<isize>().map_err(|_| ProtocolError::BadResponse {
+            let size = s.parse::<isize>().map_err(|_| Protocol::BadResponse {
                 typed_as: "bulk string",
                 error: "server bulk response size prefix is not an integer",
                 bytes: s.as_bytes().to_vec(),
@@ -192,7 +191,7 @@ fn read<R: BufRead>(mut r: R) -> Result<RawResponse, Error> {
             // so we'll just give up
             unimplemented!();
         }
-        c => Err(ProtocolError::BadResponse {
+        c => Err(Protocol::BadResponse {
             typed_as: "unknown",
             error: "invalid response type prefix",
             bytes: vec![c],
@@ -224,7 +223,7 @@ impl From<Vec<u8>> for RawResponse {
 #[cfg(test)]
 mod test {
     use super::{read, Error, RawResponse};
-    use crate::ProtocolError;
+    use crate::error::Protocol;
     use serde_json::{self, Map, Value};
     use std::io::{self, Cursor};
 
@@ -247,7 +246,7 @@ mod test {
     #[test]
     fn it_errors_on_bad_numbers() {
         let c = Cursor::new(b":x\r\n");
-        if let Error::Protocol(ProtocolError::BadResponse {
+        if let Error::Protocol(Protocol::BadResponse {
             typed_as, error, ..
         }) = read(c).unwrap_err()
         {
@@ -261,7 +260,7 @@ mod test {
     #[test]
     fn it_parses_errors() {
         let c = Cursor::new(b"-ERR foo\r\n");
-        if let Error::Protocol(ProtocolError::Internal { ref msg }) = read(c).unwrap_err() {
+        if let Error::Protocol(Protocol::Internal { ref msg }) = read(c).unwrap_err() {
             assert_eq!(msg, "foo");
         } else {
             unreachable!();
@@ -284,7 +283,7 @@ mod test {
     #[test]
     fn it_errors_on_bad_sizes() {
         let c = Cursor::new(b"$x\r\n\r\n");
-        if let Error::Protocol(ProtocolError::BadResponse {
+        if let Error::Protocol(Protocol::BadResponse {
             typed_as, error, ..
         }) = read(c).unwrap_err()
         {
@@ -373,7 +372,7 @@ mod test {
     #[test]
     fn json_error_on_number() {
         let c = Cursor::new(b":9\r\n");
-        if let Error::Protocol(ProtocolError::BadType {
+        if let Error::Protocol(Protocol::BadType {
             expected,
             ref received,
         }) = read_json(c).unwrap_err()
@@ -388,7 +387,7 @@ mod test {
     #[test]
     fn it_errors_on_unknown_resp_type() {
         let c = Cursor::new(b"^\r\n");
-        if let Error::Protocol(ProtocolError::BadResponse {
+        if let Error::Protocol(Protocol::BadResponse {
             typed_as, error, ..
         }) = read_json(c).unwrap_err()
         {

--- a/src/proto/single/resp.rs
+++ b/src/proto/single/resp.rs
@@ -157,7 +157,7 @@ fn read<R: BufRead>(mut r: R) -> Result<RawResponse, Error> {
         }
         b'$' => {
             // Bulk String
-            // https://redis.io/topics/error::protocol#resp-bulk-strings
+            // https://redis.io/topics/protocol#resp-bulk-strings
             let mut bytes = Vec::with_capacity(32);
             r.read_until(b'\n', &mut bytes)?;
             let s = std::str::from_utf8(&bytes[0..bytes.len() - 2]).map_err(|_| {

--- a/src/proto/single/resp.rs
+++ b/src/proto/single/resp.rs
@@ -37,7 +37,7 @@ pub fn read_json<R: BufRead, T: serde::de::DeserializeOwned>(r: R) -> Result<Opt
         RawResponse::String(ref s) => {
             return serde_json::from_str(s)
                 .map(Some)
-                .map_err(Error::DeserializePayload);
+                .map_err(Error::Serialization);
         }
         RawResponse::Blob(ref b) if b == b"OK" => {
             return Ok(None);
@@ -48,7 +48,7 @@ pub fn read_json<R: BufRead, T: serde::de::DeserializeOwned>(r: R) -> Result<Opt
             }
             return serde_json::from_slice(b)
                 .map(Some)
-                .map_err(Error::DeserializePayload);
+                .map_err(Error::Serialization);
         }
         RawResponse::Null => return Ok(None),
         _ => {}
@@ -73,7 +73,7 @@ pub fn read_hi<R: BufRead>(r: R) -> Result<Hi, Error> {
     let rr = read(r)?;
     if let RawResponse::String(ref s) = rr {
         if let Some(s) = s.strip_prefix("HI ") {
-            return serde_json::from_str(s).map_err(Error::DeserializePayload);
+            return serde_json::from_str(s).map_err(Error::Serialization);
         }
     }
 
@@ -357,7 +357,7 @@ mod test {
     #[test]
     fn it_errors_on_bad_json_blob() {
         let c = Cursor::new(b"$9\r\n{\"hello\"}\r\n");
-        if let Error::DeserializePayload(err) = read_json(c).unwrap_err() {
+        if let Error::Serialization(err) = read_json(c).unwrap_err() {
             let _: serde_json::Error = err;
         } else {
             unreachable!();
@@ -367,7 +367,7 @@ mod test {
     #[test]
     fn it_errors_on_bad_json_string() {
         let c = Cursor::new(b"+{\"hello\"}\r\n");
-        if let Error::DeserializePayload(err) = read_json(c).unwrap_err() {
+        if let Error::Serialization(err) = read_json(c).unwrap_err() {
             let _: serde_json::Error = err;
         } else {
             unreachable!();

--- a/src/proto/single/resp.rs
+++ b/src/proto/single/resp.rs
@@ -95,7 +95,7 @@ pub fn read_ok<R: BufRead>(r: R) -> Result<(), Error> {
 
 // ----------------------------------------------
 //
-// below is the implementation of the Redis RESP error::protocol
+// below is the implementation of the Redis RESP protocol
 //
 // ----------------------------------------------
 
@@ -113,7 +113,7 @@ fn read<R: BufRead>(mut r: R) -> Result<RawResponse, Error> {
     match cmdbuf[0] {
         b'+' => {
             // Simple String
-            // https://redis.io/topics/error::protocol#resp-simple-strings
+            // https://redis.io/topics/protocol#resp-simple-strings
             let mut s = String::new();
             r.read_line(&mut s)?;
 
@@ -125,7 +125,7 @@ fn read<R: BufRead>(mut r: R) -> Result<RawResponse, Error> {
         }
         b'-' => {
             // Error
-            // https://redis.io/topics/error::protocol#resp-errors
+            // https://redis.io/topics/protocol#resp-errors
             let mut s = String::new();
             r.read_line(&mut s)?;
 
@@ -137,7 +137,7 @@ fn read<R: BufRead>(mut r: R) -> Result<RawResponse, Error> {
         }
         b':' => {
             // Integer
-            // https://redis.io/topics/error::protocol#resp-integers
+            // https://redis.io/topics/protocol#resp-integers
             let mut s = String::with_capacity(32);
             r.read_line(&mut s)?;
 
@@ -188,7 +188,7 @@ fn read<R: BufRead>(mut r: R) -> Result<RawResponse, Error> {
         }
         b'*' => {
             // Arrays
-            // https://redis.io/topics/error::protocol#resp-arrays
+            // https://redis.io/topics/protocol#resp-arrays
             //
             // not used in faktory.
             // *and* you can't really skip them unless you parse them.

--- a/src/proto/single/resp.rs
+++ b/src/proto/single/resp.rs
@@ -1,5 +1,4 @@
-use super::Error;
-use crate::error::Protocol;
+use crate::error::{Error, Protocol};
 use std::io::prelude::*;
 
 fn bad(expected: &'static str, got: &RawResponse) -> Protocol {
@@ -222,8 +221,8 @@ impl From<Vec<u8>> for RawResponse {
 
 #[cfg(test)]
 mod test {
-    use super::{read, Error, RawResponse};
-    use crate::error::Protocol;
+    use super::{read, RawResponse};
+    use crate::error::{Error, Protocol};
     use serde_json::{self, Map, Value};
     use std::io::{self, Cursor};
 

--- a/src/proto/single/resp.rs
+++ b/src/proto/single/resp.rs
@@ -35,7 +35,9 @@ pub fn read_json<R: BufRead, T: serde::de::DeserializeOwned>(r: R) -> Result<Opt
             return Ok(None);
         }
         RawResponse::String(ref s) => {
-            return Ok(serde_json::from_str(s).map(Some)?);
+            return serde_json::from_str(s)
+                .map(Some)
+                .map_err(Error::DeserializePayload);
         }
         RawResponse::Blob(ref b) if b == b"OK" => {
             return Ok(None);
@@ -44,7 +46,9 @@ pub fn read_json<R: BufRead, T: serde::de::DeserializeOwned>(r: R) -> Result<Opt
             if b.is_empty() {
                 return Ok(None);
             }
-            return Ok(serde_json::from_slice(b).map(Some)?);
+            return serde_json::from_slice(b)
+                .map(Some)
+                .map_err(Error::DeserializePayload);
         }
         RawResponse::Null => return Ok(None),
         _ => {}
@@ -69,7 +73,7 @@ pub fn read_hi<R: BufRead>(r: R) -> Result<Hi, Error> {
     let rr = read(r)?;
     if let RawResponse::String(ref s) = rr {
         if let Some(s) = s.strip_prefix("HI ") {
-            return Ok(serde_json::from_str(s)?);
+            return serde_json::from_str(s).map_err(Error::DeserializePayload);
         }
     }
 

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -41,7 +41,10 @@ impl TlsStream<TcpStream> {
     ///
     /// If `url` is given, but does not specify a port, it defaults to 7419.
     pub fn connect(url: Option<&str>) -> Result<Self, Error> {
-        TlsStream::with_connector(TlsConnector::builder().build()?, url)
+        TlsStream::with_connector(
+            TlsConnector::builder().build().map_err(Error::TlsStream)?,
+            url,
+        )
     }
 
     /// Create a new TLS connection over TCP using a non-default TLS configuration.

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -1,5 +1,5 @@
 use crate::proto::{self, Reconnect};
-use failure::Error;
+use crate::Error;
 use native_tls::TlsConnector;
 use native_tls::TlsStream as NativeTlsStream;
 use std::io;
@@ -70,14 +70,13 @@ where
     /// Create a new TLS connection on an existing stream with a non-default TLS configuration.
     pub fn new(stream: S, tls: TlsConnector, hostname: &str) -> io::Result<Self> {
         let stream = tls
-            .clone()
             .connect(hostname, stream)
             .map_err(|e| io::Error::new(io::ErrorKind::ConnectionAborted, e))?;
 
         Ok(TlsStream {
             connector: tls,
             hostname: hostname.to_string(),
-            stream: stream,
+            stream,
         })
     }
 }

--- a/tests/consumer.rs
+++ b/tests/consumer.rs
@@ -1,4 +1,3 @@
-extern crate failure;
 extern crate faktory;
 extern crate mockstream;
 extern crate serde_json;

--- a/tests/mock/mod.rs
+++ b/tests/mock/mod.rs
@@ -81,12 +81,12 @@ impl Stream {
 
         let mut inner = Inner {
             take_next: 0,
-            streams: streams,
+            streams,
         };
         let mine = inner.take_stream();
 
         Stream {
-            mine: mine,
+            mine,
             all: Arc::new(Mutex::new(inner)),
         }
     }

--- a/tests/producer.rs
+++ b/tests/producer.rs
@@ -1,4 +1,3 @@
-extern crate failure;
 extern crate faktory;
 extern crate mockstream;
 extern crate serde_json;
@@ -93,7 +92,7 @@ fn queue_control() {
     s.ignore(0);
 
     s.ok(0);
-    p.queue_pause(&vec!["test", "test2"]).unwrap();
+    p.queue_pause(&["test", "test2"]).unwrap();
 
     s.ok(0);
     p.queue_resume(&["test3".to_string(), "test4".to_string()])

--- a/tests/real.rs
+++ b/tests/real.rs
@@ -1,4 +1,3 @@
-extern crate failure;
 extern crate faktory;
 extern crate serde_json;
 extern crate url;


### PR DESCRIPTION
_Closes https://github.com/jonhoo/faktory-rs/issues/8
Closes https://github.com/jonhoo/faktory-rs/issues/27_

**This is a breaking change.**

Removes `failure`, and in its place implements errors as standard enums compatible with `std::error::Error`, powered by `thiserror`.
Also includes some minor cleanup and reorganization:
- The top-level crate now exposes `faktory::error::ProtocolError`, which is the old `FaktoryError` type, and `faktory::error::Error`, which is all possible errors returned by the crate (one of which is `faktory::error::ProtocolError`).
- Errors under `producer` and `consumer` now return the top-level `faktory::error::Error` type (this solves #8).
- I also made `Job.failure` into `pub`, instead of `pub(crate)`; I did this because clippy was complaining that it's unused. If you disagree happy to change it back.
- I made a couple other minor edits based on clippy recommendations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jonhoo/faktory-rs/28)
<!-- Reviewable:end -->
