### PR TITLE
Remove chrono default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ sha2 = "0.10.0"
 hostname = "0.3"
 libc = "0.2"
 rand = "0.8"
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4", features = ["serde", "clock"], default-features = false }
 url = "2"
 atomic-option = "0.1"
 fnv = "1.0.3"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,7 +1,7 @@
 jobs:
  - template: default.yml@templates
    parameters:
-     minrust: 1.56
+     minrust: 1.57
  - job: integration
    displayName: cargo test (real)
    pool:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,7 +1,7 @@
 jobs:
  - template: default.yml@templates
    parameters:
-     minrust: 1.54
+     minrust: 1.56
  - job: integration
    displayName: cargo test (real)
    pool:

--- a/src/proto/single/resp.rs
+++ b/src/proto/single/resp.rs
@@ -145,7 +145,7 @@ fn read<R: BufRead>(mut r: R) -> Result<RawResponse, Error> {
             let l = s.len() - 2;
             s.truncate(l);
 
-            match (&*s).parse::<isize>() {
+            match (*s).parse::<isize>() {
                 Ok(i) => Ok(RawResponse::Number(i)),
                 Err(_) => Err(error::Protocol::BadResponse {
                     typed_as: "integer",

--- a/tests/real.rs
+++ b/tests/real.rs
@@ -147,9 +147,9 @@ fn queue() {
     let mut c = c.connect(None).unwrap();
 
     let mut p = Producer::connect(None).unwrap();
-    p.queue_pause(&[local]).unwrap();
     p.enqueue(Job::new(local, vec![Value::from(1)]).on_queue(local))
         .unwrap();
+    p.queue_pause(&[local]).unwrap();
 
     let had_job = c.run_one(0, &[local]).unwrap();
     assert!(!had_job);


### PR DESCRIPTION
While trying to track down why our use of chrono (which does not require any WASM) was importing WASM deps, I noticed that faktory is requiring the default features of chrono without using them.  This PR removes all unused features from chrono.

If any testing other than `cargo test` is needed, please let me know.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jonhoo/faktory-rs/29)
<!-- Reviewable:end -->
