### PR TITLE
Tech debt

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ If you want to **submit** jobs to Faktory, use `Client`.
 
 ```rust
 use faktory::{Client, Job};
-let mut c = Client::connect(None).await.unwrap();
+let mut c = Client::connect().await.unwrap();
 c.enqueue(Job::new("foobar", vec!["z"])).await.unwrap();
 ```
 
@@ -84,7 +84,7 @@ let mut w = Worker::builder()
         Ok::<(), io::Error>(())
     })
     .with_rustls() // available on `rustls` feature only
-    .connect(None)
+    .connect()
     .await
     .unwrap();
 

--- a/examples/run.rs
+++ b/examples/run.rs
@@ -49,7 +49,7 @@ async fn main() {
     let tx = Arc::new(tx);
 
     // create a producing client
-    let mut c = Client::connect(None)
+    let mut c = Client::connect()
         .await
         .expect("client successfully connected");
 
@@ -61,7 +61,7 @@ async fn main() {
     // create a worker
     let mut w = Worker::builder()
         .register("job_type", JobHandler::new(Arc::clone(&tx)))
-        .connect(None)
+        .connect()
         .await
         .expect("Connected to server");
 

--- a/examples/run_to_completion.rs
+++ b/examples/run_to_completion.rs
@@ -16,7 +16,7 @@ async fn main() {
             println!("{:?}", j);
             Ok::<(), IOError>(())
         })
-        .connect(None)
+        .connect()
         .await
         .expect("Connected to server")
         .run_to_completion(&["default"])

--- a/src/bin/loadtest.rs
+++ b/src/bin/loadtest.rs
@@ -41,7 +41,7 @@ async fn main() {
     // ensure that we can actually connect to the server;
     // will create a client, run a handshake with Faktory,
     // and drop the cliet immediately afterwards;
-    if let Err(e) = Client::connect(None).await {
+    if let Err(e) = Client::connect().await {
         println!("{}", e);
         process::exit(1);
     }
@@ -57,7 +57,7 @@ async fn main() {
         let popped = sync::Arc::clone(&popped);
         set.spawn(async move {
             // make producer and consumer
-            let mut p = Client::connect(None).await.unwrap();
+            let mut p = Client::connect().await.unwrap();
             let mut worker = WorkerBuilder::default()
                 .register_fn("SomeJob", |_| {
                     Box::pin(async move {
@@ -69,7 +69,7 @@ async fn main() {
                         }
                     })
                 })
-                .connect(None)
+                .connect()
                 .await
                 .unwrap();
             let mut rng = rand::rngs::OsRng;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@
 //! ```no_run
 //! # tokio_test::block_on(async {
 //! use faktory::{Client, Job};
-//! let mut client = Client::connect(None).await.unwrap();
+//! let mut client = Client::connect().await.unwrap();
 //! client.enqueue(Job::new("foobar", vec!["z"])).await.unwrap();
 //!
 //! let (enqueued_count, errors) = client.enqueue_many([Job::new("foobar", vec!["z"]), Job::new("foobar", vec!["z"])]).await.unwrap();
@@ -82,7 +82,7 @@
 //!         Ok::<(), io::Error>(())
 //!     })
 //!     .with_rustls() // available on `rustls` feature only
-//!     .connect(None)
+//!     .connect()
 //!     .await
 //!     .unwrap();
 //!

--- a/src/proto/batch/mod.rs
+++ b/src/proto/batch/mod.rs
@@ -34,7 +34,7 @@ pub(crate) use cmd::{CommitBatch, GetBatchStatus, OpenBatch};
 /// # use faktory::Error;
 /// use faktory::{Client, Job, ent::Batch};
 ///
-/// let mut cl = Client::connect(None).await?;
+/// let mut cl = Client::connect().await?;
 /// let job1 = Job::builder("job_type").build();
 /// let job2 = Job::builder("job_type").build();
 /// let job_cb = Job::builder("callback_job_type").build();
@@ -57,7 +57,7 @@ pub(crate) use cmd::{CommitBatch, GetBatchStatus, OpenBatch};
 /// # tokio_test::block_on(async {
 /// # use faktory::{Client, Job, Error};
 /// # use faktory::ent::Batch;
-/// # let mut cl = Client::connect(None).await?;
+/// # let mut cl = Client::connect().await?;
 /// let parent_job1 = Job::builder("job_type").build();
 /// let parent_job2 = Job::builder("another_job_type").build();
 /// let parent_cb = Job::builder("callback_job_type").build();
@@ -97,7 +97,7 @@ pub(crate) use cmd::{CommitBatch, GetBatchStatus, OpenBatch};
 /// # use faktory::{Job, Client};
 /// # use faktory::ent::{Batch, CallbackState};
 /// # tokio_test::block_on(async {
-/// let mut cl = Client::connect(None).await?;
+/// let mut cl = Client::connect().await?;
 /// let job = Job::builder("job_type").build();
 /// let cb_job = Job::builder("callback_job_type").build();
 /// let b = Batch::builder()
@@ -109,7 +109,7 @@ pub(crate) use cmd::{CommitBatch, GetBatchStatus, OpenBatch};
 /// b.add(job).await?;
 /// b.commit().await?;
 ///
-/// let mut t = Client::connect(None).await?;
+/// let mut t = Client::connect().await?;
 /// let s = t.get_batch_status(bid).await?.unwrap();
 /// assert_eq!(s.total, 1);
 /// assert_eq!(s.pending, 1);

--- a/src/proto/single/mod.rs
+++ b/src/proto/single/mod.rs
@@ -111,8 +111,8 @@ pub struct Job {
     /// Defaults to 600 seconds.
     #[serde(
         skip_serializing_if = "Option::is_none",
-        serialize_with = "utils::ser_optional_duration",
-        deserialize_with = "utils::deser_as_optional_duration"
+        serialize_with = "utils::ser_optional_duration_in_seconds",
+        deserialize_with = "utils::deser_as_optional_duration_in_seconds"
     )]
     #[builder(default = "Some(Duration::from_secs(JOB_DEFAULT_RESERVED_FOR_SECS))")]
     pub reserve_for: Option<Duration>,

--- a/src/proto/single/mod.rs
+++ b/src/proto/single/mod.rs
@@ -2,6 +2,7 @@ use crate::Error;
 use chrono::{DateTime, Utc};
 use derive_builder::Builder;
 use std::collections::HashMap;
+use std::time::Duration;
 use tokio::io::{AsyncBufRead, AsyncWrite, AsyncWriteExt};
 
 mod cmd;
@@ -22,7 +23,7 @@ pub mod ent;
 pub use id::BatchId;
 
 const JOB_DEFAULT_QUEUE: &str = "default";
-const JOB_DEFAULT_RESERVED_FOR_SECS: usize = 600;
+const JOB_DEFAULT_RESERVED_FOR_SECS: u64 = 600;
 const JOB_DEFAULT_RETRY_COUNT: isize = 25;
 const JOB_DEFAULT_PRIORITY: u8 = 5;
 const JOB_DEFAULT_BACKTRACE: usize = 0;
@@ -108,9 +109,13 @@ pub struct Job {
     /// How long to allow this job to run for.
     ///
     /// Defaults to 600 seconds.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[builder(default = "Some(JOB_DEFAULT_RESERVED_FOR_SECS)")]
-    pub reserve_for: Option<usize>,
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "utils::ser_optional_duration",
+        deserialize_with = "utils::deser_as_optional_duration"
+    )]
+    #[builder(default = "Some(Duration::from_secs(JOB_DEFAULT_RESERVED_FOR_SECS))")]
+    pub reserve_for: Option<Duration>,
 
     /// Number of times to retry this job.
     ///
@@ -300,7 +305,10 @@ mod test {
 
         assert!(job.enqueued_at.is_none());
         assert!(job.at.is_none());
-        assert_eq!(job.reserve_for, Some(JOB_DEFAULT_RESERVED_FOR_SECS));
+        assert_eq!(
+            job.reserve_for,
+            Some(Duration::from_secs(JOB_DEFAULT_RESERVED_FOR_SECS))
+        );
         assert_eq!(job.retry, Some(JOB_DEFAULT_RETRY_COUNT));
         assert_eq!(job.priority, Some(JOB_DEFAULT_PRIORITY));
         assert_eq!(job.backtrace, Some(JOB_DEFAULT_BACKTRACE));

--- a/src/proto/single/resp.rs
+++ b/src/proto/single/resp.rs
@@ -172,8 +172,8 @@ pub struct ServerSnapshot {
     pub version: semver::Version,
 
     /// Faktory server process uptime in seconds.
-    #[serde(deserialize_with = "utils::deser_duration")]
-    #[serde(serialize_with = "utils::ser_duration")]
+    #[serde(deserialize_with = "utils::deser_duration_in_seconds")]
+    #[serde(serialize_with = "utils::ser_duration_in_seconds")]
     pub uptime: Duration,
 
     /// Number of clients connected to the server.

--- a/src/proto/single/resp.rs
+++ b/src/proto/single/resp.rs
@@ -196,7 +196,7 @@ pub struct ServerSnapshot {
 /// # tokio_test::block_on(async {
 /// use faktory::Client;
 ///
-/// let mut client = Client::connect(None).await.unwrap();
+/// let mut client = Client::connect().await.unwrap();
 /// let _server_state = client.current_info().await.unwrap();
 /// # });
 /// ```

--- a/src/proto/single/utils.rs
+++ b/src/proto/single/utils.rs
@@ -30,12 +30,34 @@ where
     serializer.serialize_u64(secs)
 }
 
+pub(crate) fn ser_optional_duration<S>(
+    value: &Option<Duration>,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    match value {
+        None => serializer.serialize_none(),
+        Some(dur) => serializer.serialize_u64(dur.as_secs()),
+    }
+}
+
 pub(crate) fn deser_duration<'de, D>(value: D) -> Result<Duration, D::Error>
 where
     D: Deserializer<'de>,
 {
     let secs = u64::deserialize(value)?;
     Ok(Duration::from_secs(secs))
+}
+
+pub(crate) fn deser_as_optional_duration<'de, D>(value: D) -> Result<Option<Duration>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    Ok(u64::deserialize(value)
+        .ok()
+        .map(|value| (Duration::from_secs(value))))
 }
 
 pub(crate) fn ser_server_time<S>(value: &NaiveTime, serializer: S) -> Result<S::Ok, S::Error>

--- a/src/proto/single/utils.rs
+++ b/src/proto/single/utils.rs
@@ -22,7 +22,7 @@ pub(crate) fn gen_random_wid() -> String {
     gen_random_id(WORKER_ID_LENGTH)
 }
 
-pub(crate) fn ser_duration<S>(value: &Duration, serializer: S) -> Result<S::Ok, S::Error>
+pub(crate) fn ser_duration_in_seconds<S>(value: &Duration, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
 {
@@ -43,7 +43,7 @@ where
     }
 }
 
-pub(crate) fn deser_duration<'de, D>(value: D) -> Result<Duration, D::Error>
+pub(crate) fn deser_duration_in_seconds<'de, D>(value: D) -> Result<Duration, D::Error>
 where
     D: Deserializer<'de>,
 {
@@ -51,7 +51,9 @@ where
     Ok(Duration::from_secs(secs))
 }
 
-pub(crate) fn deser_as_optional_duration<'de, D>(value: D) -> Result<Option<Duration>, D::Error>
+pub(crate) fn deser_as_optional_duration_in_seconds<'de, D>(
+    value: D,
+) -> Result<Option<Duration>, D::Error>
 where
     D: Deserializer<'de>,
 {
@@ -115,8 +117,8 @@ mod test {
     fn test_ser_deser_duration() {
         #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
         struct FaktoryServer {
-            #[serde(deserialize_with = "deser_duration")]
-            #[serde(serialize_with = "ser_duration")]
+            #[serde(deserialize_with = "deser_duration_in_seconds")]
+            #[serde(serialize_with = "ser_duration_in_seconds")]
             uptime: Duration,
         }
 

--- a/src/proto/single/utils.rs
+++ b/src/proto/single/utils.rs
@@ -30,7 +30,7 @@ where
     serializer.serialize_u64(secs)
 }
 
-pub(crate) fn ser_optional_duration<S>(
+pub(crate) fn ser_optional_duration_in_seconds<S>(
     value: &Option<Duration>,
     serializer: S,
 ) -> Result<S::Ok, S::Error>

--- a/src/proto/single/utils.rs
+++ b/src/proto/single/utils.rs
@@ -55,9 +55,7 @@ pub(crate) fn deser_as_optional_duration<'de, D>(value: D) -> Result<Option<Dura
 where
     D: Deserializer<'de>,
 {
-    Ok(u64::deserialize(value)
-        .ok()
-        .map(|value| (Duration::from_secs(value))))
+    Ok(u64::deserialize(value).ok().map(Duration::from_secs))
 }
 
 pub(crate) fn ser_server_time<S>(value: &NaiveTime, serializer: S) -> Result<S::Ok, S::Error>

--- a/src/proto/utils.rs
+++ b/src/proto/utils.rs
@@ -27,10 +27,6 @@ pub(crate) fn url_parse(url: &str) -> Result<Url, Error> {
     Ok(url)
 }
 
-pub(crate) fn parse_provided_or_from_env(url: Option<&str>) -> Result<Url, Error> {
-    url_parse(url.unwrap_or(&get_env_url()))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/tls/native_tls.rs
+++ b/src/tls/native_tls.rs
@@ -24,7 +24,7 @@ use tokio_native_tls::{native_tls::TlsConnector, TlsConnector as AsyncTlsConnect
 /// use faktory::native_tls::TlsStream;
 /// use tokio::io::BufStream;
 ///
-/// let stream = TlsStream::connect(None).await.unwrap();
+/// let stream = TlsStream::connect().await.unwrap();
 /// let buffered = BufStream::new(stream);
 /// let cl = Client::connect_with(buffered, None).await.unwrap();
 /// # drop(cl);
@@ -40,7 +40,7 @@ pub struct TlsStream<S> {
 }
 
 impl TlsStream<TokioTcpStream> {
-    /// Create a new TLS connection over TCP.
+    /// Create a new TLS connection to Faktory over TCP.
     ///
     /// If `url` is not given, will use the standard Faktory environment variables. Specifically,
     /// `FAKTORY_PROVIDER` is read to get the name of the environment variable to get the address
@@ -53,12 +53,23 @@ impl TlsStream<TokioTcpStream> {
     /// ```
     ///
     /// If `url` is given, but does not specify a port, it defaults to 7419.
-    pub async fn connect(url: Option<&str>) -> Result<Self, Error> {
+    pub async fn connect() -> Result<Self, Error> {
         TlsStream::with_connector(
             TlsConnector::builder()
                 .build()
                 .map_err(error::Stream::NativeTls)?,
-            url,
+            None,
+        )
+        .await
+    }
+
+    /// Create a new TLS connection to Faktory over TCP using specified address.
+    pub async fn connect_to(addr: &str) -> Result<Self, Error> {
+        TlsStream::with_connector(
+            TlsConnector::builder()
+                .build()
+                .map_err(error::Stream::NativeTls)?,
+            Some(addr),
         )
         .await
     }

--- a/src/worker/health.rs
+++ b/src/worker/health.rs
@@ -5,7 +5,6 @@ use std::{
     sync::{atomic, Arc},
     time::{self, Duration},
 };
-use tokio::time::sleep as tokio_sleep;
 
 const CHECK_STATE_INTERVAL: Duration = Duration::from_millis(100);
 const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(5);
@@ -34,9 +33,11 @@ where
         let mut target = STATUS_RUNNING;
 
         let mut last = time::Instant::now();
+        let mut check_state_interval = tokio::time::interval(CHECK_STATE_INTERVAL);
+        check_state_interval.tick().await;
 
         loop {
-            tokio_sleep(CHECK_STATE_INTERVAL).await;
+            check_state_interval.tick().await;
 
             // has a worker failed?
             let worker_failure = target == STATUS_RUNNING

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -210,6 +210,14 @@ impl<E> Worker<E> {
             ),
         }
     }
+
+    /// Tell if this worker has been terminated.
+    ///
+    /// Running a terminate worker ([`Worker::run_one`], [`Worker::run`], [`Worker::run_to_completion`])
+    /// will cause a panic. If the worker is terminated, you will need to build and run a new worker instead.
+    pub fn is_terminated(&self) -> bool {
+        self.terminated
+    }
 }
 
 enum Failed<E: StdError, JE: StdError> {
@@ -323,6 +331,8 @@ impl<E: StdError + 'static + Send> Worker<E> {
     /// discontinued due to a signal from the Faktory server or a graceful shutdown signal,
     /// calling this method will mean you are trying to run a _terminated_ worker which will
     /// cause a panic. You will need to build and run a new worker instead.
+    /// 
+    /// You can check if the worker has been terminated with [`Worker::is_terminated`].
     pub async fn run_one<Q>(&mut self, worker: usize, queues: &[Q]) -> Result<bool, Error>
     where
         Q: AsRef<str> + Sync,
@@ -430,6 +440,8 @@ impl<E: StdError + 'static + Send> Worker<E> {
     /// Note that if you provided a shutdown signal when building this worker (see [`WorkerBuilder::with_graceful_shutdown`]),
     /// and this signal resolved, the worker will be marked as terminated and calling this method will cause a panic.
     /// You will need to build and run a new worker instead.
+    /// 
+    /// You can check if the worker has been terminated with [`Worker::is_terminated`].
     pub async fn run<Q>(&mut self, queues: &[Q]) -> Result<StopDetails, Error>
     where
         Q: AsRef<str>,

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -331,7 +331,7 @@ impl<E: StdError + 'static + Send> Worker<E> {
     /// discontinued due to a signal from the Faktory server or a graceful shutdown signal,
     /// calling this method will mean you are trying to run a _terminated_ worker which will
     /// cause a panic. You will need to build and run a new worker instead.
-    /// 
+    ///
     /// You can check if the worker has been terminated with [`Worker::is_terminated`].
     pub async fn run_one<Q>(&mut self, worker: usize, queues: &[Q]) -> Result<bool, Error>
     where
@@ -440,7 +440,7 @@ impl<E: StdError + 'static + Send> Worker<E> {
     /// Note that if you provided a shutdown signal when building this worker (see [`WorkerBuilder::with_graceful_shutdown`]),
     /// and this signal resolved, the worker will be marked as terminated and calling this method will cause a panic.
     /// You will need to build and run a new worker instead.
-    /// 
+    ///
     /// You can check if the worker has been terminated with [`Worker::is_terminated`].
     pub async fn run<Q>(&mut self, queues: &[Q]) -> Result<StopDetails, Error>
     where

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -125,7 +125,7 @@ type CallbacksRegistry<E> = FnvHashMap<String, Callback<E>>;
 ///
 /// let mut w = Worker::builder()
 ///     .register_fn("foo", process_job)
-///     .connect(None)
+///     .connect()
 ///     .await
 ///     .unwrap();
 ///
@@ -153,7 +153,7 @@ type CallbacksRegistry<E> = FnvHashMap<String, Callback<E>>;
 ///         println!("{:?}", job);
 ///         Ok::<(), io::Error>(())
 ///     })
-///     .connect(None)
+///     .connect()
 ///     .await
 ///     .unwrap();
 /// });

--- a/src/worker/runner.rs
+++ b/src/worker/runner.rs
@@ -38,7 +38,7 @@ use std::future::Future;
 ///
 /// let mut w = WorkerBuilder::default()
 ///     .register("foo", handler)
-///     .connect(None)
+///     .connect()
 ///     .await
 ///     .unwrap();
 ///

--- a/tests/real/community.rs
+++ b/tests/real/community.rs
@@ -756,5 +756,6 @@ async fn test_panic_in_handler() {
         .unwrap();
 
     // same for async handler, note how the test run is not interrupted with a panic
+    assert!(!w.is_terminated());
     assert!(w.run_one(0, &[local]).await.unwrap());
 }

--- a/tests/real/community.rs
+++ b/tests/real/community.rs
@@ -493,7 +493,7 @@ async fn test_jobs_pushed_in_bulk() {
             Job::builder("broken")
                 .jid(JobId::new("3sZCbdp8e9WX__1"))
                 .queue(local_3)
-                .reserve_for(864001) // reserve_for exceeded
+                .reserve_for(Duration::from_secs(864001)) // reserve_for exceeded
                 .build(),
             // plus some valid ones:
             Job::builder("very_special").queue(local_4).build(),


### PR DESCRIPTION
 - Use ::connect() vs ::connect_to(&str) as per [thread](https://github.com/jonhoo/faktory-rs/pull/64#discussion_r1720922173)
 
- Job's `reserve_for` is now using Duration;

- We are adding public  `Wokrer::is_terminated` so that they can check and _not_ run a terminated worker;

- Refactoring: using `tokio::time::interval` in the heartbeat thread instead of `tokio::time::sleep`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jonhoo/faktory-rs/79)
<!-- Reviewable:end -->
