### PR TITLE
Release 0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,20 +18,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Made the bindings async (supporting sync job handlers though)
-- What used to be `Consumer` and `Producer` is now `Worker` and `Client`
-- Instantiate `Client` with a more ergonomic `Client::connect`
-- `Client` now holds a `Box<dyn Connection>` for stream instead of generic `S`
-- Use new types for ids (`JobId` and `WorkerId`) instead of strings
-- Use optional `Duration` for `Job::reserve_for` instead of usize
-- `Worker::run` now returns a result with `StopDetails`
-- `Faktory` image version bumped from `1.8.0` to `1.9.1`
+- Made the bindings async (supporting sync job handlers though) ([#49])
+- What used to be `Consumer` and `Producer` is now `Worker` and `Client`([#49])
+- Instantiate `Client` with a more ergonomic `Client::connect` ([#79])
+- `Client` now holds a `Box<dyn Connection>` for stream instead of generic `S` ([#64])
+- Use new types for ids (`JobId` and `WorkerId`) instead of strings ([#49])
+- Use optional `Duration` for `Job::reserve_for` instead of usize ([#79])
+- `Worker::run` now returns a result with `StopDetails` ([#57])
+- `Faktory` image version bumped from `1.8.0` to `1.9.1` ([#72], [#80])
 
 [#49]: https://github.com/jonhoo/faktory-rs/pull/49
 [#57]: https://github.com/jonhoo/faktory-rs/pull/57
 [#59]: https://github.com/jonhoo/faktory-rs/pull/59
 [#63]: https://github.com/jonhoo/faktory-rs/pull/63
+[#64]: https://github.com/jonhoo/faktory-rs/pull/64
+[#72]: https://github.com/jonhoo/faktory-rs/pull/72
 [#74]: https://github.com/jonhoo/faktory-rs/pull/74
+[#79]: https://github.com/jonhoo/faktory-rs/pull/79
+[#80]: https://github.com/jonhoo/faktory-rs/pull/80
 
 ## [0.12.5] - 2024-02-18
 
@@ -46,5 +50,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#51]: https://github.com/jonhoo/faktory-rs/pull/51
 [#54]: https://github.com/jonhoo/faktory-rs/pull/54
 
-[unreleased]: https://github.com/jonhoo/faktory-rs/compare/v0.12.5...v0.13.0
+[0.13.0]: https://github.com/jonhoo/faktory-rs/compare/v0.12.5...v0.13.0
 [0.12.5]: https://github.com/jonhoo/faktory-rs/compare/v0.12.4...v0.12.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#48]: https://github.com/jonhoo/faktory-rs/pull/48
 [#51]: https://github.com/jonhoo/faktory-rs/pull/51
 [#54]: https://github.com/jonhoo/faktory-rs/pull/54
+
 [unreleased]: https://github.com/jonhoo/faktory-rs/compare/v0.13.0...HEAD
 [0.13.0]: https://github.com/jonhoo/faktory-rs/compare/v0.12.5...v0.13.0
 [0.12.5]: https://github.com/jonhoo/faktory-rs/compare/v0.12.4...v0.12.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
 ## [0.13.0] - 2024-10-27
 
 ### Added
@@ -51,7 +63,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#48]: https://github.com/jonhoo/faktory-rs/pull/48
 [#51]: https://github.com/jonhoo/faktory-rs/pull/51
 [#54]: https://github.com/jonhoo/faktory-rs/pull/54
-
 [unreleased]: https://github.com/jonhoo/faktory-rs/compare/v0.13.0...HEAD
 [0.13.0]: https://github.com/jonhoo/faktory-rs/compare/v0.12.5...v0.13.0
 [0.12.5]: https://github.com/jonhoo/faktory-rs/compare/v0.12.4...v0.12.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## [0.13.0] - 2024-10-27
 
 ### Added
@@ -50,5 +52,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#51]: https://github.com/jonhoo/faktory-rs/pull/51
 [#54]: https://github.com/jonhoo/faktory-rs/pull/54
 
+[unreleased]: https://github.com/jonhoo/faktory-rs/compare/v0.13.0...HEAD
 [0.13.0]: https://github.com/jonhoo/faktory-rs/compare/v0.12.5...v0.13.0
 [0.12.5]: https://github.com/jonhoo/faktory-rs/compare/v0.12.4...v0.12.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.13.0] - 2024-10-27
 
 ### Added
 
@@ -15,8 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Error::Stream` for underlying 'native_tls' and 'rustls' errors
 - Shutdown signal via `WorkerBuilder::with_graceful_shutdown`
 - Shutdown timeout via `WorkerBuilder::shutdown_timeout`
-- [Faktory Enterprise Edition] Batch jobs (`Batch`, `BatchId`, `BatchStatus`)
-- [Faktory Enterprise Edition] Setting and getting a job's progress
+- Faktory Enterprise Edition: batch jobs (`Batch`, `BatchId`, `BatchStatus`)
+- Faktory Enterprise Edition: setting and getting a job's progress
 
 ### Changed
 
@@ -40,5 +40,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Faktory Enterprise Edition] Setting and getting a job's progress
 
 
-[unreleased]: https://github.com/jonhoo/faktory-rs/compare/ff2a27bd841b097c1db0208ad03d9363d89d21c1...release-0.13
-[0.12.5]: https://github.com/jonhoo/faktory-rs/compare/b5ddd2130661ef8aa72790db3f2868706fc7408c...ff2a27bd841b097c1db0208ad03d9363d89d21c1
+[unreleased]: https://github.com/jonhoo/faktory-rs/compare/v0.12.5...v0.13.0
+[0.12.5]: https://github.com/jonhoo/faktory-rs/compare/v0.12.4...v0.12.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,44 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- `Client::current_info` and `FaktoryState` struct
+- `Client` method for pausing, resuming, and removing queues
+- TLS configurations options to `WorkerBuilder`
+- `Error::Stream` for underlying 'native_tls' and 'rustls' errors
+- Shutdown signal via `WorkerBuilder::with_graceful_shutdown`
+- Shutdown timeout via `WorkerBuilder::shutdown_timeout`
+- [Faktory Enterprise Edition] Batch jobs (`Batch`, `BatchId`, `BatchStatus`)
+- [Faktory Enterprise Edition] Setting and getting a job's progress
+
+### Changed
+
+- Made the bindings async (supporting sync job handlers though)
+- What used to be `Consumer` and `Producer` is now `Worker` and `Client`
+- Instantiate `Client` with a more ergonomic `Client::connect`
+- `Client` now holds a `Box<dyn Connection>` for stream instead of generic `S`
+- Use new types for ids (`JobId` and `WorkerId`) instead of strings
+- Use optional `Duration` for `Job::reserve_for` instead of usize
+- `Worker::run` now returns a result with `StopDetails`
+- `Faktory` image version bumped from `1.8.0` to `1.9.1`
+
+
+## [0.12.5] - 2024-02-18
+
+### Added
+
+- `JobRunner` trait and `ConsumerBuilder::register_runner`
+- Support for enqueuing numerous jobs with `Producer::enqueue_many`
+- [Faktory Enterprise Edition] Batch jobs (`Batch`, `BatchId`, `BatchStatus`)
+- [Faktory Enterprise Edition] Setting and getting a job's progress
+
+
+[unreleased]: https://github.com/jonhoo/faktory-rs/compare/ff2a27bd841b097c1db0208ad03d9363d89d21c1...release-0.13
+[0.12.5]: https://github.com/jonhoo/faktory-rs/compare/b5ddd2130661ef8aa72790db3f2868706fc7408c...ff2a27bd841b097c1db0208ad03d9363d89d21c1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `Client::current_info` and `FaktoryState` struct
-- `Client` method for pausing, resuming, and removing queues
-- TLS configurations options to `WorkerBuilder`
-- `Error::Stream` for underlying 'native_tls' and 'rustls' errors
-- Shutdown signal via `WorkerBuilder::with_graceful_shutdown`
-- Shutdown timeout via `WorkerBuilder::shutdown_timeout`
-- Faktory Enterprise Edition: batch jobs (`Batch`, `BatchId`, `BatchStatus`)
-- Faktory Enterprise Edition: setting and getting a job's progress
+- `Error::Stream` for underlying 'native_tls' and 'rustls' errors ([#49])
+- Shutdown signal via `WorkerBuilder::with_graceful_shutdown` ([#57])
+- Shutdown timeout via `WorkerBuilder::shutdown_timeout` ([#57])
+- `Client` method for pausing, resuming, and removing queues ([#59])
+- `Client::current_info` and `FaktoryState` struct ([#63])
+- TLS configurations options to `WorkerBuilder` ([#74])
 
 ### Changed
 
@@ -29,16 +27,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Worker::run` now returns a result with `StopDetails`
 - `Faktory` image version bumped from `1.8.0` to `1.9.1`
 
+[#49]: https://github.com/jonhoo/faktory-rs/pull/49
+[#57]: https://github.com/jonhoo/faktory-rs/pull/57
+[#59]: https://github.com/jonhoo/faktory-rs/pull/59
+[#63]: https://github.com/jonhoo/faktory-rs/pull/63
+[#74]: https://github.com/jonhoo/faktory-rs/pull/74
 
 ## [0.12.5] - 2024-02-18
 
 ### Added
 
-- `JobRunner` trait and `ConsumerBuilder::register_runner`
-- Support for enqueuing numerous jobs with `Producer::enqueue_many`
-- [Faktory Enterprise Edition] Batch jobs (`Batch`, `BatchId`, `BatchStatus`)
-- [Faktory Enterprise Edition] Setting and getting a job's progress
+- `JobRunner` trait and `ConsumerBuilder::register_runner` ([#51])
+- Support for enqueuing numerous jobs with `Producer::enqueue_many` ([#54])
+- Faktory Enterprise Edition: Batch jobs (`Batch`, `BatchId`, `BatchStatus`) ([#48])
+- Faktory Enterprise Edition: Setting and getting a job's progress ([#48])
 
+[#48]: https://github.com/jonhoo/faktory-rs/pull/48
+[#51]: https://github.com/jonhoo/faktory-rs/pull/51
+[#54]: https://github.com/jonhoo/faktory-rs/pull/54
 
 [unreleased]: https://github.com/jonhoo/faktory-rs/compare/v0.12.5...v0.13.0
 [0.12.5]: https://github.com/jonhoo/faktory-rs/compare/v0.12.4...v0.12.5

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -434,7 +434,7 @@ dependencies = [
 
 [[package]]
 name = "faktory"
-version = "0.12.5"
+version = "0.13.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "faktory"
-version = "0.12.5"
+version = "0.13.0"
 authors = ["Jon Gjengset <jon@thesquareplanet.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Some breaking changes have been introduced sine `0.12.5` , such as:
  - we've made everything async (but still leaving space for sync handlers)
  - `Client` will be instantiated with a more ergonomic `Client::connect()`  (allowing to `connect_to(&str)` as well)
  - `Client` will now hold a boxed `dyn Connection`
  - we try to only require references from the bindings' user where we can do without owning values internally
  
We've also added:
  - `Client::current_info` and `FaktoryState` struct;
  - More queue actions: `Client::queue_remove`, `Client::queue_remove_all`, `Client::queue_resume_all`,  and `Client::queue_pause_all`;
  - TLS configurations options to `WorkerBuilder`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jonhoo/faktory-rs/81)
<!-- Reviewable:end -->
